### PR TITLE
Explicitly send X-Plex-Token as URL parameter

### DIFF
--- a/resources/lib/plex/plexserver.py
+++ b/resources/lib/plex/plexserver.py
@@ -450,6 +450,9 @@ class PlexMediaServer:
         query_args = urlparse.parse_qsl(url_parts.query)
         query_args += options.items()
 
+        if self.token is not None:
+            query_args += { 'X-Plex-Token' : self.token }.items()
+
         new_query_args = urllib.urlencode(query_args, True)
 
         return "%s | %s" % (urlparse.urlunparse((url_parts.scheme, url_parts.netloc, url_parts.path, url_parts.params, new_query_args, url_parts.fragment)), self.plex_identification_string)


### PR DESCRIPTION
As of Kodi 17.0b6-Krypton [1], curl will no longer send all headers blindly. 

This results in (at least) thumbnails not loading, and errors:
```
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option ' X-Plex-Platform: KODI'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Client-Identifier: ...'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Client-Platform: KODI'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Device: PleXBMC'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Device-Name: My PleXBMC Client'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Language: en'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Model: unknown'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Platform-Version: Windows'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Product: PleXBMC'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Provides: player'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Token: ...'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-User: ...'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Version: 4.1.0'
ERROR: CCurlFile::Stat - Failed: HTTP response code said error(22) for https://192.168.1.2:32400/photo/:/transcode?url=http%3A%2F%2Flocalhost%3A32400%2Flibrary%2Fmetadata%2F3%2Fthumb%2F1427952599&width=720&height=720 | X-Plex-Platform=KODI&X-Plex-Client-Platform=KODI&X-Plex-User=...&X-Plex-Device-Name=My%20PleXBMC%20Client&X-Plex-Provides=player&X-Plex-Token=...&X-Plex-Model=unknown&X-Plex-Platform-Version=Windows&X-Plex-Client-Identifier=...&X-Plex-Device=PleXBMC&X-Plex-Product=PleXBMC&X-Plex-Language=en&X-Plex-Version=4.1.0
```

This patch adds the token as a URL Parameter [2] of the URL returned from get_kodi_header_formatted_url

References:
[1] https://github.com/xbmc/xbmc/commit/ed00cd660dbbd40cb678b5b3ddfce569bf31bb85
[2] https://support.plex.tv/hc/en-us/articles/204059436-Finding-your-account-token-X-Plex-Token